### PR TITLE
Add a user in the Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Docker files for development of GUI applications with Python 3 + PyQt6, and opti
 ## Docker Hub Repository
 Visit the [docker-pyqt6 Docker Hub Repository](https://hub.docker.com/repository/docker/dasycarpum/pyqt6/general) for more details and image downloads.
 
-## How to use v1.0.0 on Linux
+## How to use v1 on Linux
 *Tested on Ubuntu 22.04*
 
 ### Prerequisites
@@ -29,9 +29,24 @@ You can test if everything works with a small testing application. Follow these 
     - `docker-app-1` is the name of your Docker container.
     - To revert this permission, use `xhost -local:docker-app-1`.
 
-2. **Start the Docker Container**:
+2a. **Start the Docker Container with Docker Compose**:
     - Navigate to the directory containing your `docker-compose.yml`.
     - Run `docker-compose up -d` to start the container.
+
+2b. **Alternatively, Start the Container directly from the Docker Image**   
+    To run the container, use the following command:
+
+```bash
+docker run --rm -it \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e PYTHONPATH=/usr/src/app \
+    -e DISPLAY=$DISPLAY \
+    -e QT_QPA_PLATFORM=xcb \
+    -u qtuser \
+    dasycarpum/pyqt6:alone
+```
+(To copy the code, click on the code block and press `Ctrl+C` on your keyboard.)
+
 
 You should see a window similar to this :
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LIBGL_ALWAYS_INDIRECT=1 \
     QT_DEBUG_PLUGINS=1
 
+# Add user
+RUN apt-get update && apt-get install -y adduser \
+    && adduser --quiet --disabled-password --gecos '' qtuser \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory in the container
 WORKDIR /usr/src/app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   app:
     image: dasycarpum/pyqt6:alone
+    user: qtuser
     build:
       context: ../
       dockerfile: docker/Dockerfile


### PR DESCRIPTION
Adding a user in a Dockerfile is a common practice for several important reasons related to security and permissions:

**1. Principle of Least Privilege**: By default, Docker containers run as the root user. Running applications as root, even within containers, can be a security risk. If the application inside the container has a vulnerability that is exploited, running as root could give an attacker more control over the container and potentially the host system. By creating a specific user for your application, you ensure that it runs with only the permissions it needs.
**2.Container Isolation**: Docker is designed to provide isolated environments for applications. Running containers as non-root users enhances this isolation. If a container is compromised, the limited permissions of the user can help contain the damage and prevent the attacker from gaining control of the host or other containers.
**3. Compliance with Best Practices**: Many organizations have security policies that require applications to run with non-privileged users. By adding a user in the Dockerfile, you adhere to these best practices and make your container more suitable for enterprise environments.
**4. File Permissions Management**: When sharing volumes between the host and the container, running as a non-root user helps manage file permissions more effectively. Files created by the container will have the user's permissions, avoiding potential issues with file ownership and access rights.
**5. Avoiding Unintentional Changes**: Running as a non-root user reduces the risk of accidental changes to critical system files within the container, which could destabilize or break the application.